### PR TITLE
Updated LOC2196Consta

### DIFF
--- a/2001-3000/LOC2196Consta.xml
+++ b/2001-3000/LOC2196Consta.xml
@@ -36,21 +36,28 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          </xi:include>
       </encodingDesc>
       <profileDesc>
-         <langUsage><language ident="en">English</language></langUsage>
+         <langUsage>
+            <language ident="en">English</language>
+            <language ident="gez">Gəʿəz</language>
+            <language ident="grc">Greek</language>
+         </langUsage>
       </profileDesc>
       <revisionDesc>
-         <change who="PL" when="2016-04-27">harmonized typology based on Eugenia indication in Issue 48.</change>
-         <change who="PL" when="2016-03-21"> Created file from
-                                                  google spreadsheet </change>
+         <change when="2023-05-26" who="CH">Added names and Wikidata</change>
+         <change who="PL" when="2016-04-27">harmonized typology based on Eugenia indication in Issue 48</change>
+         <change who="PL" when="2016-03-21"> Created file from google spreadsheet </change>
          <change who="ES" when="2016-02-09">CREATED: place</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <listPlace>
-            <place type="town">
-               <placeName>Constantinople</placeName>
-               <placeName type="alt">Qwǝsṭǝnṭǝnya</placeName>
+            <place type="town" sameAs="wd:Q16869">
+               <placeName xml:id="n1" xml:lang="en">Constantinople</placeName>
+               <placeName xml:id="n2" xml:lang="gez">ቍስጥንጥንያ፡</placeName>
+               <placeName corresp="#n2" xml:lang="gez" type="normalized">Qwǝsṭǝnṭǝnya</placeName>
+               <placeName xml:lang="grc" xml:id="n3">Κωνσταντινούπολη</placeName>
+               <placeName corresp="#n3" xml:lang="grc" type="normalized">Kōnstaninūpolē</placeName>
             </place>
          </listPlace>
       </body>

--- a/2001-3000/LOC2196Consta.xml
+++ b/2001-3000/LOC2196Consta.xml
@@ -24,8 +24,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <date>2016-03-21</date>
          </publicationStmt>
          <sourceDesc>
-            <p>A TEI file converted from the ETHIO-authority
-                                                  google spreadsheet</p>
+            <p>A TEI file converted from the ETHIO-authority google spreadsheet</p>
          </sourceDesc>
       </fileDesc>
       <encodingDesc>
@@ -52,7 +51,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <listPlace>
-            <place type="town" sameAs="wd:Q16869">
+            <place type="city" sameAs="wd:Q16869">
                <placeName xml:id="n1" xml:lang="en">Constantinople</placeName>
                <placeName xml:id="n2" xml:lang="gez">ቍስጥንጥንያ፡</placeName>
                <placeName corresp="#n2" xml:lang="gez" type="normalized">Qwǝsṭǝnṭǝnya</placeName>

--- a/2001-3000/LOC2594Dayral.xml
+++ b/2001-3000/LOC2594Dayral.xml
@@ -47,7 +47,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <listPlace>
-            <place type="monastery">
+            <place type="monastery" sameAs="paths.places.112">
                <placeName>Dayr al-ʾAbyaḍ</placeName>
                <placeName type="alt">White Monastery</placeName>
             </place>

--- a/2001-3000/LOC2594Dayral.xml
+++ b/2001-3000/LOC2594Dayral.xml
@@ -47,11 +47,14 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <listPlace>
-            <place type="monastery" sameAs="paths.places.112">
+            <place type="monastery" sameAs="wd:Q202661">
                <placeName>Dayr al-ʾAbyaḍ</placeName>
                <placeName type="alt">White Monastery</placeName>
             </place>
          </listPlace>
+         <listRelation>
+            <relation name="skos:exactMatch" active="LOC2594Dayral" passive="https://atlas.paths-erc.eu/places/112"></relation>
+         </listRelation>
       </body>
    </text>
 </TEI>

--- a/3001-4000/LOC3010Ethiop.xml
+++ b/3001-4000/LOC3010Ethiop.xml
@@ -38,6 +38,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
          <langUsage><language ident="en">English</language><language ident="gez">Gǝʿǝz</language></langUsage>
       </profileDesc>
       <revisionDesc>
+         <change when="2023-05-30" who="CH">Updated names and added Wikidata.</change>
          <change who="PL" when="2016-04-27">harmonized typology based on Eugenia indication in Issue 48.</change>
          <change who="PL" when="2016-03-21"> Created file from
                                                   google spreadsheet </change>
@@ -47,9 +48,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
    <text xml:base="https://betamasaheft.eu/">
       <body>
          <listPlace>
-            <place type="country">
-               <placeName corresp="#n1" xml:lang="en">Ethiopia</placeName>
+            <place type="country" sameAs="Q115"> 
                <placeName xml:id="n1" xml:lang="gez">ኢትዮጵያ</placeName>
+               <placeName corresp="#n2" xml:lang="gez" type="normalized">ʾItyoṗyā</placeName>
+               <placeName xml:id="n2" xml:lang="en">Ethiopia</placeName>
                <listBibl type="secondary">
                   <bibl>
                      <ptr target="bm:Shiferaw2018Nationalism"/>

--- a/new/LOC7371Atrib.xml
+++ b/new/LOC7371Atrib.xml
@@ -50,20 +50,21 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <place sameAs="wd:Q755738" type="town">
                     <placeName xml:id="n1" xml:lang="en">Athribis</placeName>
                     <placeName xml:lang="en" xml:id="n2">Athribis in Upper Egypt</placeName>
-                    <placeName xml:id="n3" xml:lang="gez">አትሪብ፡ </placeName>
-                    <placeName corresp="#n3" xml:lang="gez" type="normalized">ʾAtrib</placeName>
-                    <placeName xml:lang="grc" xml:id="n4">Ἄθλιβις</placeName>
-                    <placeName corresp="#n4" xml:lang="grc" type="normalized">Áthlibis</placeName>
-                    <placeName xml:lang="grc" xml:id="n5">Ἄθλιβις Ἄνω Αιγύπτου</placeName>
-                    <placeName xml:lang="grc" corresp="#n5" type="normalized">Athlibis Anō Aigyptū</placeName>
-                    <placeName xml:lang="ar" xml:id="n6">أتريبس</placeName>
-                    <placeName corresp="#n6" xml:lang="ar" type="normalized">ʾAtrībis</placeName>
-                    <placeName xml:id="n7" xml:lang="ar">أثريب</placeName>
-                    <placeName corresp="#n7" xml:lang="ar" type="normalized">ʾAṯrīb</placeName>
-                    <placeName xml:id="n8" xml:lang="cop">ⲁⲧⲣⲉⲡⲉ</placeName>
-                    <placeName corresp="#n8" type="normalized" xml:lang="cop">Atrepe</placeName>
-                    <placeName xml:id="n9" xml:lang="cop">ⲁⲑⲣⲏⲃⲓ</placeName>
-                    <placeName corresp="#n9" type="normalized" xml:lang="cop">Athrēbi</placeName>
+                    <placeName xml:id="n3" xml:lang="en">Atripe</placeName>
+                    <placeName xml:id="n4" xml:lang="gez">አትሪብ፡ </placeName>
+                    <placeName corresp="#n4" xml:lang="gez" type="normalized">ʾAtrib</placeName>
+                    <placeName xml:lang="grc" xml:id="n5">Ἄθλιβις</placeName>
+                    <placeName corresp="#n5" xml:lang="grc" type="normalized">Áthlibis</placeName>
+                    <placeName xml:lang="grc" xml:id="n6">Ἄθλιβις Ἄνω Αιγύπτου</placeName>
+                    <placeName xml:lang="grc" corresp="#n6" type="normalized">Athlibis Anō Aigyptū</placeName>
+                    <placeName xml:lang="ar" xml:id="n7">أتريبس</placeName>
+                    <placeName corresp="#n7" xml:lang="ar" type="normalized">ʾAtrībis</placeName>
+                    <placeName xml:id="n8" xml:lang="ar">أثريب</placeName>
+                    <placeName corresp="#n8" xml:lang="ar" type="normalized">ʾAṯrīb</placeName>
+                    <placeName xml:id="n9" xml:lang="cop">ⲁⲧⲣⲉⲡⲉ</placeName>
+                    <placeName corresp="#n9" type="normalized" xml:lang="cop">Atrepe</placeName>
+                    <placeName xml:id="n10" xml:lang="cop">ⲁⲑⲣⲏⲃⲓ</placeName>
+                    <placeName corresp="#n10" type="normalized" xml:lang="cop">Athrēbi</placeName>
                 </place>
                 <listRelation>
                     <relation name="dcterms:relation" active="LOC7371Atrib" passive="LOC2594Dayral">

--- a/new/LOC7371Atrib.xml
+++ b/new/LOC7371Atrib.xml
@@ -1,0 +1,64 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7371Atrib" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Athribis</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <t:langUsage xmlns:t="http://www.tei-c.org/ns/1.0">
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+                <language ident="grc">Greek</language>
+                <language ident="ar">Arabic</language>
+            </t:langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-05-30">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place sameAs="wd:Q755738" type="city">
+                    <placeName xml:id="n1" xml:lang="en">Athribis</placeName>
+                    <placeName xml:id="n2" xml:lang="gez">አትሪብ፡ </placeName>
+                    <placeName corresp="#n2" xml:lang="gez" type="normalized">ʾAtrib</placeName>
+                    <placeName xml:lang="grc" xml:id="n3">Ἄθλιβις</placeName>
+                    <placeName corresp="#n3" xml:lang="grc" type="normalized">Áthlibis</placeName>
+                    <placeName xml:lang="ar" xml:id="n4">أتريبس</placeName>
+                    <placeName corresp="#n4" xml:lang="ar" type="normalized">ʾAtrībis</placeName>
+                </place>
+                <listRelation>
+                    <relation name="saws:isAttributedToAuthor" active="LOC7371Atrib" passive="PRS7054Michael"/>
+                </listRelation>
+            </listPlace>
+        </body>
+    </text>
+</TEI>

--- a/new/LOC7372Paralos.xml
+++ b/new/LOC7372Paralos.xml
@@ -52,6 +52,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             </listPlace>
             <listRelation>
                 <relation name="lawd:hasAttestation" active="LOC7372Paralos" passive="LIT2375Synaxa"/>
+                <relation name="skos:exactMatch" active="LOC7372Paralos" passive="https://atlas.paths-erc.eu/places/132"/>
             </listRelation>
         </body>
     </text>

--- a/new/LOC7372Paralos.xml
+++ b/new/LOC7372Paralos.xml
@@ -1,0 +1,58 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7372Paralos" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Paralos</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-05-30">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="town" sameAs="paths.places.132">
+                    <placeName xml:id="n1" xml:lang="en">Paralos</placeName>
+                    <placeName xml:id="n2" xml:lang="gez">ቡርልስ፡</placeName>
+                    <placeName corresp="#n2" xml:lang="gez" type="normalized">Burləs</placeName>
+                </place>
+            </listPlace>
+            <listRelation>
+                <relation name="lawd:hasAttestation" active="LOC7372Paralos" passive="LIT2375Synaxa"/>
+            </listRelation>
+        </body>
+    </text>
+</TEI>

--- a/new/LOC7373Atrib.xml
+++ b/new/LOC7373Atrib.xml
@@ -1,7 +1,7 @@
 <?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
 type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7371Atrib" xml:lang="en" type="place">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7373Atrib" xml:lang="en" type="place">
     <teiHeader>
         <fileDesc>
             <titleStmt>
@@ -32,13 +32,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <abstract>
                 <p/>
             </abstract>
-            <t:langUsage xmlns:t="http://www.tei-c.org/ns/1.0">
+            <langUsage>
                 <language ident="en">English</language>
                 <language ident="gez">Gǝʿǝz</language>
-                <language ident="grc">Greek</language>
-                <language ident="ar">Arabic</language>
-                <language ident="cop">Coptic</language>
-            </t:langUsage>
+            </langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2023-05-30">Created entity</change>
@@ -47,27 +44,26 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
         <body>
             <listPlace>
-                <place sameAs="wd:Q755738" type="town">
+                <place sameAs="wd:Q755734" type="town">
                     <placeName xml:id="n1" xml:lang="en">Athribis</placeName>
-                    <placeName xml:lang="en" xml:id="n2">Athribis in Upper Egypt</placeName>
+                    <placeName xml:id="n2" xml:lang="en">Athribis in Lower Egypt</placeName>
                     <placeName xml:id="n3" xml:lang="gez">አትሪብ፡ </placeName>
                     <placeName corresp="#n3" xml:lang="gez" type="normalized">ʾAtrib</placeName>
                     <placeName xml:lang="grc" xml:id="n4">Ἄθλιβις</placeName>
                     <placeName corresp="#n4" xml:lang="grc" type="normalized">Áthlibis</placeName>
-                    <placeName xml:lang="grc" xml:id="n5">Ἄθλιβις Ἄνω Αιγύπτου</placeName>
-                    <placeName xml:lang="grc" corresp="#n5" type="normalized">Athlibis Anō Aigyptū</placeName>
-                    <placeName xml:lang="ar" xml:id="n6">أتريبس</placeName>
-                    <placeName corresp="#n6" xml:lang="ar" type="normalized">ʾAtrībis</placeName>
-                    <placeName xml:id="n7" xml:lang="ar">أثريب</placeName>
-                    <placeName corresp="#n7" xml:lang="ar" type="normalized">ʾAṯrīb</placeName>
-                    <placeName xml:id="n8" xml:lang="cop">ⲁⲧⲣⲉⲡⲉ</placeName>
-                    <placeName corresp="#n8" type="normalized" xml:lang="cop">Atrepe</placeName>
+                    <placeName xml:lang="grc" xml:id="n5">Ἄθλιβις Κάτω Αιγύπτου</placeName>
+                    <placeName xml:lang="grc" corresp="#n5" type="normalized">Athlibis Kátō Aigyptū</placeName>
+                    <placeName xml:lang="grc" xml:id="n6">Ἄθριβις</placeName>
+                    <placeName xml:lang="grc" corresp="#n6" type="normalized">Athribis</placeName>
+                    <placeName xml:lang="ar" xml:id="n7">أتريبس</placeName>
+                    <placeName corresp="#n7" xml:lang="ar" type="normalized">ʾAtrībis</placeName>
+                    <placeName xml:id="n8" xml:lang="ar">أثريب</placeName>
+                    <placeName corresp="#n8" xml:lang="ar" type="normalized">ʾAṯrīb</placeName>
                     <placeName xml:id="n9" xml:lang="cop">ⲁⲑⲣⲏⲃⲓ</placeName>
                     <placeName corresp="#n9" type="normalized" xml:lang="cop">Athrēbi</placeName>
                 </place>
                 <listRelation>
-                    <relation name="dcterms:relation" active="LOC7371Atrib" passive="LOC2594Dayral">
-                        <desc>Located not far from the White Monastery.</desc></relation>
+                    <relation name="saws:isAttributedToAuthor" active="LOC7373Atrib" passive="PRS7054Michael"/>
                 </listRelation>
             </listPlace>
         </body>

--- a/new/LOC7373Atrib.xml
+++ b/new/LOC7373Atrib.xml
@@ -63,7 +63,6 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <placeName corresp="#n9" type="normalized" xml:lang="cop">Athrēbi</placeName>
                 </place>
                 <listRelation>
-                    <relation name="saws:isAttributedToAuthor" active="LOC7373Atrib" passive="PRS7054Michael"/>
                     <relation name="skos:exactMatch" active="#LOC7373Atrib" passive="https://atlas.paths-erc.eu/places/8"></relation>
                 </listRelation>
             </listPlace>

--- a/new/LOC7373Atrib.xml
+++ b/new/LOC7373Atrib.xml
@@ -35,6 +35,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <langUsage>
                 <language ident="en">English</language>
                 <language ident="gez">Gǝʿǝz</language>
+                <language ident="grc">Greek</language>
+                <language ident="cop">Coptic</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>
@@ -47,23 +49,24 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <place sameAs="wd:Q755734" type="town">
                     <placeName xml:id="n1" xml:lang="en">Athribis</placeName>
                     <placeName xml:id="n2" xml:lang="en">Athribis in Lower Egypt</placeName>
-                    <placeName xml:id="n3" xml:lang="gez">አትሪብ፡ </placeName>
-                    <placeName corresp="#n3" xml:lang="gez" type="normalized">ʾAtrib</placeName>
-                    <placeName xml:lang="grc" xml:id="n4">Ἄθλιβις</placeName>
-                    <placeName corresp="#n4" xml:lang="grc" type="normalized">Áthlibis</placeName>
-                    <placeName xml:lang="grc" xml:id="n5">Ἄθλιβις Κάτω Αιγύπτου</placeName>
-                    <placeName xml:lang="grc" corresp="#n5" type="normalized">Athlibis Kátō Aigyptū</placeName>
-                    <placeName xml:lang="grc" xml:id="n6">Ἄθριβις</placeName>
-                    <placeName xml:lang="grc" corresp="#n6" type="normalized">Athribis</placeName>
-                    <placeName xml:lang="ar" xml:id="n7">أتريبس</placeName>
-                    <placeName corresp="#n7" xml:lang="ar" type="normalized">ʾAtrībis</placeName>
-                    <placeName xml:id="n8" xml:lang="ar">أثريب</placeName>
-                    <placeName corresp="#n8" xml:lang="ar" type="normalized">ʾAṯrīb</placeName>
-                    <placeName xml:id="n9" xml:lang="cop">ⲁⲑⲣⲏⲃⲓ</placeName>
-                    <placeName corresp="#n9" type="normalized" xml:lang="cop">Athrēbi</placeName>
+                    <placeName xml:id="n3" xml:lang="en">Atripe</placeName>
+                    <placeName xml:id="n4" xml:lang="gez">አትሪብ፡ </placeName>
+                    <placeName corresp="#n4" xml:lang="gez" type="normalized">ʾAtrib</placeName>
+                    <placeName xml:lang="grc" xml:id="n5">Ἄθλιβις</placeName>
+                    <placeName corresp="#n5" xml:lang="grc" type="normalized">Áthlibis</placeName>
+                    <placeName xml:lang="grc" xml:id="n6">Ἄθλιβις Κάτω Αιγύπτου</placeName>
+                    <placeName xml:lang="grc" corresp="#n6" type="normalized">Athlibis Kátō Aigyptū</placeName>
+                    <placeName xml:lang="grc" xml:id="n7">Ἄθριβις</placeName>
+                    <placeName xml:lang="grc" corresp="#n7" type="normalized">Athribis</placeName>
+                    <placeName xml:lang="ar" xml:id="n8">أتريبس</placeName>
+                    <placeName corresp="#n8" xml:lang="ar" type="normalized">ʾAtrībis</placeName>
+                    <placeName xml:id="n9" xml:lang="ar">أثريب</placeName>
+                    <placeName corresp="#n9" xml:lang="ar" type="normalized">ʾAṯrīb</placeName>
+                    <placeName xml:id="n10" xml:lang="cop">ⲁⲑⲣⲏⲃⲓ</placeName>
+                    <placeName corresp="#n10" type="normalized" xml:lang="cop">Athrēbi</placeName>
                 </place>
                 <listRelation>
-                    <relation name="skos:exactMatch" active="#LOC7373Atrib" passive="https://atlas.paths-erc.eu/places/8"></relation>
+                    <relation name="skos:exactMatch" active="#LOC7373Atrib" passive="https://atlas.paths-erc.eu/places/8"/>
                 </listRelation>
             </listPlace>
         </body>

--- a/new/LOC7373Atrib.xml
+++ b/new/LOC7373Atrib.xml
@@ -64,6 +64,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </place>
                 <listRelation>
                     <relation name="saws:isAttributedToAuthor" active="LOC7373Atrib" passive="PRS7054Michael"/>
+                    <relation name="skos:exactMatch" active="#LOC7373Atrib" passive="https://atlas.paths-erc.eu/places/8"></relation>
                 </listRelation>
             </listPlace>
         </body>

--- a/new/LOC7374Armenia.xml
+++ b/new/LOC7374Armenia.xml
@@ -30,7 +30,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>Country in the Armenian highlands and Caucasus region.</p>
+                <p>Modern state in the Armenian highlands and Caucasus region.</p>
             </abstract>
             <langUsage>
                 <language ident="en">English</language>
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <text>
                 <body>
                     <listPlace>
-                        <place sameAs="wd:Q208404" type="country">
+                        <place sameAs="wd:Q399" type="country">
                             <placeName xml:id="n1" xml:lang="en">Armenia</placeName>
                             <placeName xml:id="n2" xml:lang="hy">Հայաստան</placeName>
                             <placeName corresp="#n2" xml:lang="hy" type="normalized">Hayastan</placeName>

--- a/new/LOC7374Armenia.xml
+++ b/new/LOC7374Armenia.xml
@@ -1,0 +1,66 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7374Armenia" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Armenia</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Country in the Armenian highlands and Caucasus region.</p>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+                <language ident="hy">Armenian</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-05-31">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+                <body>
+                    <listPlace>
+                        <place sameAs="wd:Q208404" type="country">
+                            <placeName xml:id="n1" xml:lang="en">Armenia</placeName>
+                            <placeName xml:id="n2" xml:lang="hy">Հայաստան</placeName>
+                            <placeName corresp="#n2" xml:lang="hy" type="normalized">Hayastan</placeName>
+                            <placeName xml:id="n3" xml:lang="gez">አርማንያ</placeName>
+                            <placeName corresp="#n3" xml:lang="gez" type="normalized">Armanya</placeName>
+                            <placeName xml:id="n4" xml:lang="gez">አርሚንያ</placeName>
+                            <placeName corresp="#n4" xml:lang="gez" type="normalized">Arminya</placeName>
+                            <placeName xml:id="n5" xml:lang="gez">አርሜንያ</placeName>
+                            <placeName corresp="#n5" xml:lang="gez" type="normalized">Armenya</placeName>
+                        </place>
+                    </listPlace>
+                </body>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LOC7374Armenia" passive="BMLacq680"/>
+                    <relation name="lawd:hasAttestation" active="#LOC7374Armenia" passive="LIT2375Synaxa"/>
+                </listRelation>
+    </text>
+</TEI>

--- a/new/LOC7374Armenia.xml
+++ b/new/LOC7374Armenia.xml
@@ -36,6 +36,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <language ident="en">English</language>
                 <language ident="gez">Gǝʿǝz</language>
                 <language ident="hy">Armenian</language>
+                <language ident="am">Amharic</language>
             </langUsage>
         </profileDesc>
         <revisionDesc>
@@ -55,12 +56,15 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                             <placeName corresp="#n4" xml:lang="gez" type="normalized">Arminya</placeName>
                             <placeName xml:id="n5" xml:lang="gez">አርሜንያ</placeName>
                             <placeName corresp="#n5" xml:lang="gez" type="normalized">Armenya</placeName>
+                            <placeName xml:id="n6" xml:lang="am">አርሜኒያ</placeName>
+                            <placeName corresp="#n6" xml:lang="am" type="normalized">ʾArmenyā</placeName>                            
+                            <placeName xml:id="n7" xml:lang="am">ኢርመን</placeName>
+                            <placeName corresp="#n7" xml:lang="am" type="normalized">ʾIrman</placeName>
                         </place>
                     </listPlace>
                 </body>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="LOC7374Armenia" passive="BMLacq680"/>
-                    <relation name="lawd:hasAttestation" active="#LOC7374Armenia" passive="LIT2375Synaxa"/>
                 </listRelation>
     </text>
 </TEI>

--- a/new/LOC7375Malig.xml
+++ b/new/LOC7375Malig.xml
@@ -1,0 +1,64 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7375Malig" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Malij</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Town in the Nile Delta, location uncertain, but probably identical with modern Milij in the province of al-Minufiyya about 20km
+                    northwest of <placeName ref="LOC7373Atrib"/>, being a bishopric from at least the eighth to the 14th centuries.</p>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+                <language ident="ar">Arabic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-06-01">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="town">
+                    <placeName xml:id="n1" xml:lang="en">Malij</placeName>
+                    <placeName xml:id="n2" xml:lang="ar">مليج</placeName>
+                    <placeName corresp="#n2" xml:lang="ar" type="normalized">Malīǧ</placeName>
+                    <placeName corresp="#n2" xml:lang="ar" type="normalized">Milīǧ</placeName>
+                    <placeName xml:id="n3" xml:lang="gez">መሊግ</placeName>
+                    <placeName corresp="#n3" xml:lang="gez" type="normalized">Malig</placeName>
+                </place>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LOC7375Malig" passive="LIT2375Synaxa"/>
+                    <relation name="lawd:hasAttestation" active="LOC7375Malig" passive="BMLacq680"/>
+                </listRelation>
+            </listPlace>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I updated LOC2196Consta, that is witnessed in BMLacq680. https://github.com/BetaMasaheft/Documentation/issues/2364
I found the notice:  <!--   please, refer to LOC3938Istanb--> in line 4, but I do not know, how to encode this reference. Using sameAs in <place> in line 55 is not possible, because there is the opportunity only for one reference and this is taken by the wikidata-reference, now.