### PR TITLE
New LOC records in Tanasee1, no. 4 (not discussed yet)

### DIFF
--- a/6001-7000/LOC6977Wagalesa.xml
+++ b/6001-7000/LOC6977Wagalesa.xml
@@ -48,6 +48,8 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 <place type="area">
                     <placeName xml:lang="gez" xml:id="n1">ወገልሳ፡</placeName>
                     <placeName xml:lang="gez" corresp="#n1" type="normalized">Wagalǝsā
+                    <note>On the southern shore of <placeName ref="LOC5888Tana"/> in the area of modern 
+                         <placeName ref="LOC1721BaherD"/>.</note>
                     </placeName>
                     
                     

--- a/new/LOC7399Dazma.xml
+++ b/new/LOC7399Dazma.xml
@@ -13,11 +13,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
-                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
                 <pubPlace>Hamburg</pubPlace>
                 <availability>
                     <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
-                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
                 </availability>
             </publicationStmt>
             <sourceDesc>
@@ -32,10 +32,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <abstract>
                 <p/>
             </abstract>
-            <t:langUsage xmlns:t="http://www.tei-c.org/ns/1.0">
+            <langUsage>
                 <language ident="en">English</language>
                 <language ident="gez">Gǝʿǝz</language>
-            </t:langUsage>
+            </langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2023-11-16">Created entity</change>
@@ -47,8 +47,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <place type="area">
                     <placeName xml:id="n1" xml:lang="gez">ደዝማ</placeName>
                     <placeName corresp="#n1" xml:lang="gez" type="normalized">Dazmā</placeName>
-                    <note>Unknown place in <placeName ref="LOC3549Gojjam"/> close to the Southern shore of 
-                        <placeName ref="LOC5888Tana"/>.</note>
+                    <note>Unknown place in <placeName ref="LOC3549Gojjam"/> near the southern shore of 
+                        <placeName ref="LOC5888Tana"/> as mentioned in <bibl><ptr target="bm:2008BoscTiesseIles"/>
+                            <citedRange unit="page">78</citedRange></bibl>.</note>
                 </place>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="LOC7399Dazma" passive="Tanasee1"/>

--- a/new/LOC7399Dazma.xml
+++ b/new/LOC7399Dazma.xml
@@ -1,0 +1,59 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7399Dazma" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Dazmā</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <t:langUsage xmlns:t="http://www.tei-c.org/ns/1.0">
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </t:langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="area">
+                    <placeName xml:id="n1" xml:lang="gez">ደዝማ</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Dazmā</placeName>
+                    <note>Unknown place in <placeName ref="LOC3549Gojjam"/> close to the Southern shore of 
+                        <placeName ref="LOC5888Tana"/>.</note>
+                </place>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LOC7399Dazma" passive="Tanasee1"/>
+                </listRelation>
+            </listPlace><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LOC7399Dazma.xml
+++ b/new/LOC7399Dazma.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Dazmā</title>
+                <title>Yəzəmā</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -45,11 +45,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <listPlace>
                 <place type="area">
-                    <placeName xml:id="n1" xml:lang="gez">ደዝማ</placeName>
-                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Dazmā</placeName>
-                    <note>Unknown place in <placeName ref="LOC3549Gojjam"/> near the southern shore of 
-                        <placeName ref="LOC5888Tana"/> as mentioned in <bibl><ptr target="bm:2008BoscTiesseIles"/>
-                            <citedRange unit="page">78</citedRange></bibl>.</note>
+                    <placeName xml:id="n1" xml:lang="gez">ይዝማ</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Yəzəmā</placeName>
+                    <note>Place in <placeName ref="LOC7114EGz"/>. Probably mentioned in <bibl><ptr target="bm:2008BoscTiesseIles"/>
+                        <citedRange unit="page">78</citedRange></bibl> with the spelling <foreign xml:lang="gez">ደዝማ</foreign>.</note>
                 </place>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="LOC7399Dazma" passive="Tanasee1"/>

--- a/new/LOC7399Dazma.xml
+++ b/new/LOC7399Dazma.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Yəzəmā</title>
+                <title>Yǝzǝmā</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -45,10 +45,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <body>
             <listPlace>
                 <place type="area">
-                    <placeName xml:id="n1" xml:lang="gez">ይዝማ</placeName>
-                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Yəzəmā</placeName>
+                    <placeName xml:id="n1" xml:lang="gez">ይዝማ፡</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Yǝzǝmā</placeName>
                     <note>Place in <placeName ref="LOC7114EGz"/>. Probably mentioned in <bibl><ptr target="bm:2008BoscTiesseIles"/>
-                        <citedRange unit="page">78</citedRange></bibl> with the spelling <foreign xml:lang="gez">ደዝማ</foreign>.</note>
+                        <citedRange unit="page">78</citedRange></bibl> with the spelling <foreign xml:lang="gez">ደዝማ፡</foreign>.</note>
                 </place>
                 <listRelation>
                     <relation name="lawd:hasAttestation" active="LOC7399Dazma" passive="Tanasee1"/>

--- a/new/LOC7400Waramit.xml
+++ b/new/LOC7400Waramit.xml
@@ -1,0 +1,64 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7400Waramit" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Warāmit</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <t:langUsage xmlns:t="http://www.tei-c.org/ns/1.0">
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </t:langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="area">
+                    <placeName></placeName>
+                </place>
+                <place type="area">
+                    <placeName xml:id="n1" xml:lang="gez">ወራሚት</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Warāmit</placeName>
+                    <placeName xml:id="n2" xml:lang="gez">ዌራሚት</placeName>
+                    <placeName corresp="#n2" xml:lang="gez" type="normalized">Werāmit</placeName>
+                    <note>On the southern shore of <placeName ref="LOC5888Tana"/> in the area of modern 
+                        <placeName ref="LOC1721BaherD"/>.</note>
+                </place>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LOC7400Waramit" passive="Tanasee1"/>
+                </listRelation>
+            </listPlace><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LOC7400Waramit.xml
+++ b/new/LOC7400Waramit.xml
@@ -13,11 +13,11 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <publicationStmt>
                 <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
                 <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
-                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                    Forschungsumgebung / Beta maṣāḥǝft</publisher>
                 <pubPlace>Hamburg</pubPlace>
                 <availability>
                     <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
-                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                        licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
                 </availability>
             </publicationStmt>
             <sourceDesc>
@@ -32,10 +32,10 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <abstract>
                 <p/>
             </abstract>
-            <t:langUsage xmlns:t="http://www.tei-c.org/ns/1.0">
+            <langUsage>
                 <language ident="en">English</language>
                 <language ident="gez">Gǝʿǝz</language>
-            </t:langUsage>
+            </langUsage>
         </profileDesc>
         <revisionDesc>
             <change who="CH" when="2023-11-16">Created entity</change>


### PR DESCRIPTION
I found place names in Tanasee1 on folia 22ra, 85ra and 184ra. Contrary to the previously pulled branches, these have not been discussed in a pull request, yet.

I opened a discussion in an issue on LOC7400Waramit and LOC6977Wagalesa in https://github.com/BetaMasaheft/Documentation/issues/2439. I think, I found enough evidence to be certain on the orthography and the location of these two places. For LOC7399Dazma, I did not find a modern place, but a hint in an article by Bosc-Tiessé, who also read this word as Dazmā and said, that it is an unidentified place (bm:2008BoscTiesseIles, p. 78). I wish to mention this reference, but I do not know, how to encode it in a note or in a relation. Since Bosc-Tiessé does not mention the manuscript Tanasee1 explicitly, I would rather not add the ID of the manuscript as a tag to the zotero lemma. However, I find the reading of Dazmā on folio 184ra is doubtful, because the character for ደ may also be read as ይ. It looks like a hybrid form to me with features of ደ and ይ. I opted to encode the variant reading as n2. Do you think, this is appropriate?

<img width="444" alt="Screenshot 2023_Dazma" src="https://github.com/BetaMasaheft/Places/assets/40291787/f65080dc-ddff-4b10-98fd-c642a7699973">



I wish to provide also wikidata for LOC7400Waramit and LOC6977Wagalesa, but wikidata does not give me a new requested password. I will create and provide an Wikidata ID as soon as possible.