### PR TITLE
New records for places in Tanasee1 (no. 5)

### DIFF
--- a/new/LOC7401Dagusmaha.xml
+++ b/new/LOC7401Dagusmaha.xml
@@ -1,0 +1,62 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7401Dagusmaha" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Dāgusmāhā</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="area">
+                    <placeName xml:id="n1" xml:lang="gez">ዳጉስማሃ</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Dāgusmāhā</placeName>
+                    <placeName xml:id="n2" xml:lang="gez">ዳጉ</placeName>
+                    <placeName corresp="#n2" xml:lang="gez" type="normalized">Dāgu</placeName>
+                    <note>Most likely a place near the southern shore of <placeName ref="LOC5888Tana"/> and perhaps a 
+                        rendering or misspelling for <placeName ref="LOC2420Daga"/> or <placeName ref="LOC2419Daga"/>
+                        </note>
+                </place>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LOC7401Dagusmaha" passive="Tanasee1"/>
+                </listRelation>
+            </listPlace><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LOC7402WabarataMaryam.xml
+++ b/new/LOC7402WabarataMaryam.xml
@@ -1,0 +1,59 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7402WabarataMaryam" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Wabarata Māryām</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="area">
+                    <placeName xml:id="n1" xml:lang="gez">ወበረተ፡ ማርያም፡</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Wabarata Māryām</placeName>
+                    <note>Most likely a place near the southern shore of <placeName ref="LOC5888Tana"/> and perhaps an 
+                        abbreviation or misspelling for <foreign xml:lang="gez">በረከተ፡ ማርያም፡</foreign>.</note>
+                </place>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LOC7402WabarataMaryam" passive="Tanasee1"/>
+                </listRelation>
+            </listPlace><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LOC7403MataqerDaramani.xml
+++ b/new/LOC7403MataqerDaramani.xml
@@ -1,0 +1,59 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7403MataqerDaramani" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Maṭāqər Daramanihā</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="area">
+                    <placeName xml:id="n1" xml:lang="gez">መጣቅር፡ ደረመኒሃ፡</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Maṭāqər Daramanihā</placeName>
+                    <note>Most likely a place near the southern shore of <placeName ref="LOC5888Tana"/> and perhaps an 
+                        abbreviation or misspelling for <foreign xml:lang="gez">መጣቅር፡ ደብረ፡ መድኃኒት፡</foreign>.</note>
+                </place>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LOC7403MataqerDaramani" passive="Tanasee1"/>
+                </listRelation>
+            </listPlace><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LOC7404GulgulmaMA.xml
+++ b/new/LOC7404GulgulmaMA.xml
@@ -1,0 +1,58 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7404GulgulmaMA" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Gulgulmā Madḫāne ʿAlam</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="area">
+                    <placeName xml:id="n1" xml:lang="gez">ጉልጉልማ፡ መድኃኔ፡ ዓለም፡</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Gulgulmā Madḫāne ʿAlam</placeName>
+                    <note>Most likely a place near the southern shore of <placeName ref="LOC5888Tana"/>.</note>
+                </place>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LOC7404GulgulmaMA" passive="Tanasee1"/>
+                </listRelation>
+            </listPlace><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LOC7405Gunagulama.xml
+++ b/new/LOC7405Gunagulama.xml
@@ -1,0 +1,58 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7405Gunagulama" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Gunāgulama</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-16">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="area">
+                    <placeName xml:id="n1" xml:lang="gez">ጉናጉለመ፡</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Gunāgulama</placeName>
+                    <note>Most likely a place near the southern shore of <placeName ref="LOC5888Tana"/>.</note>
+                </place>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LOC7405Gunagulama" passive="Tanasee1"/>
+                </listRelation>
+            </listPlace><!---->
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
In an addition in Tanasee1, I find a landgrant with a couple of place names. Most of them, I could not find and they sound quiet strange to me. Possibly they are abbreviated or misspelled: ጸሐፍነ፡ ዘገብረ፡ በዘመኑ፡ ንጉሠ፡ ሰላም፡ <persName ref="PRS4015Fasilada">ፋሲለደስ፡ </persName>
                                        ዘተሰምየ፡ በበፈቃደ፡ እግዚአብሔር፡ ዘወሀበ፡ ጉልታተ፡ ሀገር፡ ለመቅደሰ፡ <placeName ref="LOC4042Kebran">ክብራን፡</placeName>
                                        ገብርኤል፡ <placeName ref="LOC0000">ዳጉስማሃ፡ </placeName>
                                        ወ<placeName ref="LOC7384Hanita">ሐኒታ፡</placeName>
                                        ወ<placeName ref="LOC00000">ወበረተ፡ ማርያም፡</placeName>
                                        ወ<placeName ref="LOC00000">መጣቅር፡ ደረመኒ</placeName>ሃ፡
                                        ወ<placeName ref="LOC0000">ጉልጉልማ፡ መድኃኔ፡ ዓለም፡</placeName> ከመ፡ ይኩኑ፡ ረዳኢሁ፡ ለገብርኤል፡ በንዋይ፡
                                        ወበኩሉ፡ ግብር፡ ለ<placeName ref="LOC00000">ጉናጉለመ፡</placeName>
As far as I understand:
"We have written about the issue in the time of the ruler of peace Fasiladas, who was called (lacuna) to please the Lord, in a way he gave lands of fief to the holy place of Kebrān Gabrəʾel: 
Dagusmāhā (possibly the island of Dāgā, but heavily distorted), Ḥanitā (already known from another addition in the same manuscript), 
Wabarata Māryām (perhaps abbreviated for Barakata Māryām = blessing of Mary, possibly the name of a church and surrounding lands), 
Maṭāqər Daramani (or: Maṭāqər Yerimani; perhaps an abbreviation for Maṭāqər Dabra Madḫānit = The longing for the mountain of salvation - a rather unusual name for a church) 
Gulgulmā Maḫāne ʿAlam (a church with the name Saviour of the world in an area called Gulgulmā), that they shall supply the (church of) Gabrəʾel with goods and all support to Gunāgulama.

<img width="454" alt="Screenshot 2023_Dagusmaha" src="https://github.com/BetaMasaheft/Places/assets/40291787/95517a8b-c8cc-4ae8-8cd7-91849c23a12d">
