### PR TITLE
New LOC records in Tanasee1 (no. 6)

### DIFF
--- a/6001-7000/LOC6979Waramit.xml
+++ b/6001-7000/LOC6979Waramit.xml
@@ -49,7 +49,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                 <place type="area">
                     <placeName xml:lang="gez" xml:id="n1">ወራሚት፡</placeName>
                     <placeName xml:lang="gez" corresp="#n1" type="normalized">Warāmit</placeName>
-                    <placeName xml:id="n2" xml:lang="gez">ዌራሚት</placeName>
+                    <placeName xml:id="n2" xml:lang="gez">ዌራሚት፡</placeName>
                     <placeName corresp="#n2" xml:lang="gez" type="normalized">Werāmit</placeName>
                     <state type="existence" ref="Paks2"/>
                     <note>On the southern shore of <placeName ref="LOC5888Tana"/> in the area of modern 

--- a/6001-7000/LOC6979Waramit.xml
+++ b/6001-7000/LOC6979Waramit.xml
@@ -40,6 +40,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
         </profileDesc>
         <revisionDesc>
             <change who="SG" when="2018-04-25">Created entity</change>
+            <change when="2023-11-22" who="CH">Updated note on exact location, added attestation</change>
         </revisionDesc>
     </teiHeader>
     <text xml:base="https://betamasaheft.eu/">
@@ -47,19 +48,17 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             <listPlace>
                 <place type="area">
                     <placeName xml:lang="gez" xml:id="n1">ወራሚት፡</placeName>
-                    <placeName xml:lang="gez" corresp="#n1" type="normalized">Warāmit
-            </placeName>
-                    
-                    
-                    
+                    <placeName xml:lang="gez" corresp="#n1" type="normalized">Warāmit</placeName>
+                    <placeName xml:id="n2" xml:lang="gez">ዌራሚት</placeName>
+                    <placeName corresp="#n2" xml:lang="gez" type="normalized">Werāmit</placeName>
                     <state type="existence" ref="Paks2"/>
-                    
-                    
-                    
+                    <note>On the southern shore of <placeName ref="LOC5888Tana"/> in the area of modern 
+                        <placeName ref="LOC1721BaherD"/>.</note>
                 </place>
                 <listRelation>
                     <relation name="gn:locatedIn" active="LOC6979Waramit" passive="LOC3549Gojjam"/>
                     <relation name="lawd:hasAttestation" active="LOC6979Waramit" passive="LIT3951ChronSusenyos"/>
+                    <relation name="lawd:hasAttestation" active="LOC6979Waramit" passive="Tanasee1"/>
                 </listRelation>
                 
             </listPlace>

--- a/new/LOC7406Kubezt.xml
+++ b/new/LOC7406Kubezt.xml
@@ -1,0 +1,58 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7406Kubezt" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Kubəzt</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-21">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="area">
+                    <placeName xml:id="n1" xml:lang="gez">ኩብዝት፡</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Kubəzt</placeName>
+                    <note>Most likely a place near the southern shore of <placeName ref="LOC5888Tana"/>.</note>
+                </place>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LOC7406Kubezt" passive="Tanasee1"/>
+                </listRelation>
+            </listPlace><!---->
+        </body>
+    </text>
+</TEI>

--- a/new/LOC7406Kubezt.xml
+++ b/new/LOC7406Kubezt.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Kubəzt</title>
+                <title>Kubǝzt</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -46,7 +46,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
             <listPlace>
                 <place type="area">
                     <placeName xml:id="n1" xml:lang="gez">ኩብዝት፡</placeName>
-                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Kubəzt</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Kubǝzt</placeName>
                     <note>Most likely a place near the southern shore of <placeName ref="LOC5888Tana"/>.</note>
                 </place>
                 <listRelation>

--- a/new/LOC7407Desht.xml
+++ b/new/LOC7407Desht.xml
@@ -5,7 +5,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
     <teiHeader>
         <fileDesc>
             <titleStmt>
-                <title>Dəšt</title>
+                <title>Dǝšt</title>
                 <editor role="generalEditor" key="AB"/>
                 <editor key="CH"/>
                 <funder>Akademie der Wissenschaften in Hamburg</funder>
@@ -47,7 +47,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 <place type="area">
                     <placeName></placeName>
                     <placeName xml:id="n1" xml:lang="gez">ድሽት፡</placeName>
-                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Dəšt</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Dǝšt</placeName>
                     <note>Most likely a place near the southern shore of <placeName ref="LOC5888Tana"/>.</note>
                 </place>
                 <listRelation>

--- a/new/LOC7407Desht.xml
+++ b/new/LOC7407Desht.xml
@@ -1,0 +1,59 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7407Desht" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Dəšt</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p/>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="gez">Gǝʿǝz</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2023-11-21">Created entity</change>
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="area">
+                    <placeName></placeName>
+                    <placeName xml:id="n1" xml:lang="gez">ድሽት፡</placeName>
+                    <placeName corresp="#n1" xml:lang="gez" type="normalized">Dəšt</placeName>
+                    <note>Most likely a place near the southern shore of <placeName ref="LOC5888Tana"/>.</note>
+                </place>
+                <listRelation>
+                    <relation name="lawd:hasAttestation" active="LOC7407Desht" passive="Tanasee1"/>
+                </listRelation>
+            </listPlace><!---->
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
I found two new place names in Tanasee1, although they sound dubious to me and I could not identify them anywhere else.

<img width="365" alt="Screenshot 2023_Kubezt" src="https://github.com/BetaMasaheft/Places/assets/40291787/6d32d183-7568-4af6-a2da-b3feba8145db">

<img width="316" alt="Screenshot 2023_Desht" src="https://github.com/BetaMasaheft/Places/assets/40291787/88188230-4c5c-4b0a-b38a-abf25cdddade">


I saw, that there is an ID for Waramit already existing https://github.com/BetaMasaheft/Documentation/issues/2439 and updated it.

