### PR TITLE
Up LOC3589Gorgora (ID Yaqob)

### DIFF
--- a/3001-4000/LOC3589Gorgor.xml
+++ b/3001-4000/LOC3589Gorgor.xml
@@ -45,6 +45,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
             48.</change>
          <change who="PL" when="2016-03-21"> Created file from google spreadsheet </change>
          <change who="ES" when="2016-02-09">CREATED: place</change>
+         <change when="2025-08-01" who="CH">Updated PRS record for Yāʿqob in relation</change>
       </revisionDesc>
    </teiHeader>
    <text xml:base="https://betamasaheft.eu/">
@@ -153,7 +154,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><TEI
                <relation name="syriaca:has-relation-to-place" active="PRS4079Fernande" passive="LOC3589Gorgor"/>
                <relation name="syriaca:has-relation-to-place" active="PRS4386Gabriel" passive="LOC3589Gorgor"/>
                <relation name="syriaca:has-relation-to-place" active="PRS8681SeelaK" passive="LOC3589Gorgor"/>
-               <relation name="syriaca:has-relation-to-place" active="PRS10194Yaeqob" passive="LOC3589Gorgor"/>
+               <relation name="syriaca:has-relation-to-place" active="PRS10198Yaeqob" passive="LOC3589Gorgor"/>
             </listRelation>
          </listPlace>
       </body>


### PR DESCRIPTION
I updated PRS record for Yāʿqob in relation (cf. https://github.com/BetaMasaheft/Persons/pull/1172#issuecomment-3142842280).

I wonder how various syriaca-relations have been added to this record with another active as the record ID. As far as I understood, relations with a PRS as active should better be used in the PRS records in question, but not in this LOC record. Do you know, whether this is a consequent rule and does in apply to syriaca relations, as well? Or have I misunderstood something?