### PR TITLE
Create LOC7467Leca

### DIFF
--- a/new/LOC7467Leca.xml
+++ b/new/LOC7467Leca.xml
@@ -1,0 +1,70 @@
+<?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://raw.githubusercontent.com/BetaMasaheft/schema/master/tei-betamesaheft.rng" 
+type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:id="LOC7467Leca" xml:lang="en" type="place">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Lǝčče</title>
+                <editor role="generalEditor" key="AB"/>
+                <editor key="CH"/>
+                <funder>Akademie der Wissenschaften in Hamburg</funder>
+            </titleStmt>
+            <publicationStmt>
+                <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+                <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale
+                            Forschungsumgebung / Beta maṣāḥǝft</publisher>
+                <pubPlace>Hamburg</pubPlace>
+                <availability>
+                    <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                                licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+                </availability>
+            </publicationStmt>
+            <sourceDesc>
+                <p/>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <p>A digital born TEI file</p>
+        </encodingDesc>
+        <profileDesc>
+            <creation/>
+            <abstract>
+                <p>Temporary capital of <placeName ref="LOC5597Sawa"/> during the reign of <persName ref="PRS7006Menilek"/> 
+                    until <date when="1878"/> and abandoned thereafter. Located about 5 km north of <placeName ref="LOC2246DabraB"/>
+                    at 9° 42' N, 39° 33' E.</p>
+            </abstract>
+            <langUsage>
+                <language ident="en">English</language>
+                <language ident="am">Amharic</language>
+            </langUsage>
+        </profileDesc>
+        <revisionDesc>
+            <change who="CH" when="2025-09-16">Created record</change>
+            <!-- Add change element after review -->
+        </revisionDesc>
+    </teiHeader>
+    <text>
+        <body>
+            <listPlace>
+                <place type="town">
+                    <placeName xml:lang="am" xml:id="n1">ልቼ፡</placeName>
+                    <placeName xml:lang="am" type="normalized" corresp="#n1">Lǝčče</placeName>
+                    <placeName xml:lang="en" corresp="#n1">Leche</placeName>
+                    <placeName xml:lang="en" corresp="#n2">Liche</placeName>
+                    <placeName xml:lang="en" corresp="#n1">Letche</placeName>
+                    <placeName xml:lang="am" corresp="#n1">ልቼ፡</placeName> 
+                    <placeName xml:lang="am" type="normalized" corresp="#n2">Lǝčča</placeName>
+                    <placeName xml:lang="am" type="normalized" corresp="#n2">Lǝča</placeName>
+                    <country ref="LOC3010Ethiop"/>
+                    <region ref="LOC5597Sawa"/>
+                </place>
+                <listRelation>
+                    <relation name="gn:locatedIn" active="LOC7467Leca" passive="LOC5597Sawa"/>
+                    <relation name="gn:nearBy" active="LOC7467Leca" passive="LOC2246DabraB"/>
+                </listRelation>
+            </listPlace>
+            <bibl><ptr target="bm:Ege2007Lecce"/></bibl>
+        </body>
+    </text>
+</TEI>

--- a/new/LOC7467Leca.xml
+++ b/new/LOC7467Leca.xml
@@ -30,9 +30,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
         <profileDesc>
             <creation/>
             <abstract>
-                <p>Temporary capital of <placeName ref="LOC5597Sawa"/> during the reign of <persName ref="PRS7006Menilek"/> 
-                    until <date when="1878"/> and abandoned thereafter. Located about 5 km north of <placeName ref="LOC2246DabraB"/>
-                    at 9° 42' N, 39° 33' E.</p>
+                <p/>
             </abstract>
             <langUsage>
                 <language ident="en">English</language>
@@ -58,6 +56,9 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                     <placeName xml:lang="am" type="normalized" corresp="#n2">Lǝča</placeName>
                     <country ref="LOC3010Ethiop"/>
                     <region ref="LOC5597Sawa"/>
+                    <desc>Temporary capital of <placeName ref="LOC5597Sawa"/> during the reign of <persName ref="PRS7006Menilek"/> 
+                        until <date when="1878"/> and abandoned thereafter. Located about 5 km north of <placeName ref="LOC2246DabraB"/>
+                        at 9° 42' N, 39° 33' E.</desc>
                 </place>
                 <listRelation>
                     <relation name="gn:locatedIn" active="LOC7467Leca" passive="LOC5597Sawa"/>
@@ -65,6 +66,7 @@ type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
                 </listRelation>
             </listPlace>
             <bibl><ptr target="bm:Ege2007Lecce"/></bibl>
+            <bibl><ptr target="bm:LocalHistEth"/></bibl>
         </body>
     </text>
 </TEI>


### PR DESCRIPTION
According to our discussion in https://github.com/BetaMasaheft/Documentation/issues/3135.

I did not know, how and if it is easy to transform the geo data from EAe (9° 42' N, 39° 33' E.) to the form required for `<geo>` (as it is provided for example for LOC2246DabraB).

I have seen, that <abstract> is not preferred to add information LOC records and `<desc>` in `<place>` is preferred (as it is the case in LOC1216AddisA). Therefore, I moved all relevant information to `<desc>` as well.

